### PR TITLE
DI-5414 update to flink 2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to Maven Central
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+-EXNESS-[0-9]+.[0-9]*'
+      - '[0-9]+.[0-9]+.[0-9]+-EXNESS-[0-9]+.[0-9]+'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to Maven Central
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+-EXNESS-[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-EXNESS-[0-9]+.[0-9]*'
 
 jobs:
   publish:
@@ -24,7 +24,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Set version
-        run: mvn versions:set -DnewVersion=${{ github.ref_name }}
+        run: mvn versions:set -DnewVersion=${{ github.ref_name }} -DgenerateBackupPoms=false
 
       - name: Publish to Maven Central
         run: mvn -B -P release -pl :flink-sql-jdbc-driver-bundle -am deploy

--- a/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-sql-jdbc-driver-bundle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>flink-exness-jdbc-driver</artifactId>
         <groupId>com.exness</groupId>
-        <version>1.20.1</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>flink-sql-jdbc-driver-bundle</artifactId>

--- a/flink-sql-jdbc-driver/pom.xml
+++ b/flink-sql-jdbc-driver/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>flink-exness-jdbc-driver</artifactId>
         <groupId>com.exness</groupId>
-        <version>1.20.1</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>flink-sql-jdbc-driver</artifactId>
@@ -116,8 +116,6 @@
     </dependencies>
 
     <build>
-        <plugins>
-        </plugins>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverInfo.java
+++ b/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverInfo.java
@@ -38,15 +38,15 @@ import static org.apache.flink.table.jdbc.utils.DriverUtils.isNullOrWhitespaceOn
  * Driver info for flink driver, it reads driver name and version from driver.properties which will
  * be updated by flink version.
  */
-final class DriverInfo {
+public final class DriverInfo {
     private static final Logger LOG = LoggerFactory.getLogger(DriverInfo.class);
 
     private static final String DRIVER_NAME_OPTION = "flink.driver.name";
     private static final String DRIVER_VERSION_OPTION = "flink.driver.version";
-    static final String DRIVER_NAME;
-    static final String DRIVER_VERSION;
-    static final int DRIVER_VERSION_MAJOR;
-    static final int DRIVER_VERSION_MINOR;
+    public static final String DRIVER_NAME;
+    public static final String DRIVER_VERSION;
+    public static final int DRIVER_VERSION_MAJOR;
+    public static final int DRIVER_VERSION_MINOR;
 
     static {
         try {

--- a/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/JdbcExecutor.java
+++ b/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/JdbcExecutor.java
@@ -96,7 +96,7 @@ import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
  * Copy-pasted from org.apache.flink.table.client.gateway.ExecutorImpl, added the ability to connect
  * to a https gateway endpoint.
  */
-public class JdbcExecutor implements Executor {
+class JdbcExecutor implements Executor {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcExecutor.class);
     private static final long HEARTBEAT_INTERVAL_MILLISECONDS = 60_000L;

--- a/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/JdbcExecutor.java
+++ b/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/JdbcExecutor.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.rest.header.application.DeployScriptHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CancelOperationHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CloseOperationHeaders;
 import org.apache.flink.table.gateway.rest.header.session.*;
@@ -46,6 +47,7 @@ import org.apache.flink.table.gateway.rest.header.statement.CompleteStatementHea
 import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHeaders;
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
+import org.apache.flink.table.gateway.rest.message.application.DeployScriptRequestBody;
 import org.apache.flink.table.gateway.rest.message.operation.OperationMessageParameters;
 import org.apache.flink.table.gateway.rest.message.operation.OperationStatusResponseBody;
 import org.apache.flink.table.gateway.rest.message.session.*;
@@ -67,6 +69,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,13 +88,15 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.gateway.rest.handler.session.CloseSessionHandler.CLOSE_MESSAGE;
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_NAME;
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_VERSION;
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 
 /**
  * Copy-pasted from org.apache.flink.table.client.gateway.ExecutorImpl, added the ability to connect
  * to a https gateway endpoint.
  */
-class JdbcExecutor implements Executor {
+public class JdbcExecutor implements Executor {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcExecutor.class);
     private static final long HEARTBEAT_INTERVAL_MILLISECONDS = 60_000L;
@@ -179,6 +184,9 @@ class JdbcExecutor implements Executor {
         this.customHttpHeaders =
                 ClientUtils.readHeadersFromEnvironmentVariable(
                         ConfigConstants.FLINK_REST_CLIENT_HEADERS);
+        this.customHttpHeaders.add(
+                new HttpHeader("User-Agent", DRIVER_NAME + "/" + DRIVER_VERSION));
+
         try {
             // register required resource
             this.executorService = Executors.newCachedThreadPool();
@@ -328,6 +336,19 @@ class JdbcExecutor implements Executor {
                                 new SessionMessageParameters(sessionHandle),
                                 new CompleteStatementRequestBody(statement, position)))
                 .getCandidates();
+    }
+
+    @Override
+    public String deployScript(@Nullable String script, @Nullable URI uri) {
+        return getResponse(
+                        sendRequest(
+                                DeployScriptHeaders.getInstance(),
+                                new SessionMessageParameters(sessionHandle),
+                                new DeployScriptRequestBody(
+                                        script,
+                                        uri == null ? null : uri.toString(),
+                                        Collections.emptyMap())))
+                .getClusterID();
     }
 
     @Override

--- a/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/AuthUtils.java
+++ b/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/AuthUtils.java
@@ -10,6 +10,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_NAME;
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_VERSION;
+
 public class AuthUtils {
     private AuthUtils() {}
 
@@ -18,6 +21,7 @@ public class AuthUtils {
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         conn.setRequestProperty("Authorization", "Bearer " + refreshToken);
+        conn.setRequestProperty("User-Agent", DRIVER_NAME + "/" + DRIVER_VERSION);
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
 

--- a/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDriverTest.java
+++ b/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDriverTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FlinkDriverTest {
     @Test
     public void testDriverInfo() {
-        assertEquals(DRIVER_VERSION_MAJOR, 1);
+        assertEquals(DRIVER_VERSION_MAJOR, 2);
         assertEquals(DRIVER_NAME, "Flink JDBC Driver");
     }
 

--- a/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTestClose.java
+++ b/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTestClose.java
@@ -30,6 +30,9 @@ import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javax.annotation.Nullable;
+
+import java.net.URI;
 import java.nio.file.Path;
 import java.sql.Statement;
 import java.util.HashMap;
@@ -123,6 +126,11 @@ public class FlinkStatementTestClose extends FlinkJdbcDriverTestBase {
 
         @Override
         public List<String> completeStatement(String statement, int position) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String deployScript(@Nullable String script, @Nullable URI uri) {
             throw new UnsupportedOperationException();
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
 	<groupId>com.exness</groupId>
 	<artifactId>flink-exness-jdbc-driver</artifactId>
-	<version>1.20.1</version>
+	<version>2.2.0</version>
 
 	<name>Flink Exness JDBC Driver</name>
 	<packaging>pom</packaging>
@@ -75,7 +75,7 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>1.20.1</flink.version>
+		<flink.version>2.2.0</flink.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<flink.hadoop.version>2.10.2</flink.hadoop.version>
@@ -93,12 +93,13 @@ under the License.
 		<flink.forkCountUnitTest>4</flink.forkCountUnitTest>
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
-		<flink.shaded.version>17.0</flink.shaded.version>
-		<flink.shaded.jackson.version>2.14.2</flink.shaded.jackson.version>
+		<flink.shaded.version>20.0</flink.shaded.version>
+		<flink.shaded.jackson.version>2.18.2</flink.shaded.jackson.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
-		<target.java.version>1.8</target.java.version>
+		<source.java.version>11</source.java.version>
+		<target.java.version>17</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.1</log4j.version>
+		<log4j.version>2.24.3</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->
@@ -117,21 +118,21 @@ under the License.
 		<curator.version>5.4.0</curator.version>
 		<avro.version>1.11.4</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
-		<jackson-bom.version>2.15.3</jackson-bom.version>
+		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
+		<jackson-bom.version>2.18.2</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.10.1</junit5.version>
-		<archunit.version>1.2.0</archunit.version>
-		<mockito.version>3.4.6</mockito.version>
-		<powermock.version>2.0.9</powermock.version>
+		<junit5.version>5.11.4</junit5.version>
+		<archunit.version>1.4.1</archunit.version>
+		<mockito.version>5.19.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<assertj.version>3.23.1</assertj.version>
+		<assertj.version>3.27.3</assertj.version>
 		<py4j.version>0.10.9.7</py4j.version>
-		<beam.version>2.43.0</beam.version>
-		<protoc.version>3.21.7</protoc.version>
+		<beam.version>2.54.0</beam.version>
+		<protoc.version>4.32.1</protoc.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<testcontainers.version>1.19.1</testcontainers.version>
+		<testcontainers.version>1.20.2</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<commons.io.version>2.15.1</commons.io.version>
 		<japicmp.skip>false</japicmp.skip>
@@ -267,13 +268,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-asm-9</artifactId>
-				<version>9.5-${flink.shaded.version}</version>
+				<version>9.6-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-guava</artifactId>
-				<version>31.1-jre-${flink.shaded.version}</version>
+				<version>33.4.0-jre-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
@@ -291,7 +292,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<version>4.1.91.Final-${flink.shaded.version}</version>
+				<version>4.1.100.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<!-- This manages the 'javax.annotation' annotations (JSR305) -->
@@ -438,7 +439,6 @@ under the License.
 				<configuration>
 					<configLocation>tools/maven/checkstyle.xml</configLocation>
 					<suppressionsLocation>tools/maven/suppressions.xml</suppressionsLocation>
-					<encoding>UTF-8</encoding>
 					<consoleOutput>true</consoleOutput>
 					<failsOnError>true</failsOnError>
 				</configuration>


### PR DESCRIPTION
- Updated dependencies to match Flink 2.2
- Added http header with the JDBC driver version so the proxy can compare it with the latest available version and notify if user's version is outdated 